### PR TITLE
Lerp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Jake Brownson <jake@brainiumstudios.com>"]
 edition = "2018"
 
 [dependencies]
+num-traits = "0.2.6"

--- a/src/lerp.rs
+++ b/src/lerp.rs
@@ -2,8 +2,15 @@ use std::ops::{Add, Mul, Sub};
 
 pub fn lerp<T, U, V, F>(a: T, b: T, f: F) -> T
 where
-    T: Sub<T, Output = U> + Add<V, Output = T> + Clone,
+    for<'a> T: Sub<&'a T, Output = U>,
     U: Mul<F, Output = V>,
+    V: Add<T, Output = T>,
 {
-    b.clone() + (a - b) * f
+    (b - &a) * f + a
+}
+
+#[test]
+fn name() {
+    let x = lerp(0.0, 1.0, 0.25);
+    print!("{}", x);
 }

--- a/src/lerp.rs
+++ b/src/lerp.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Mul, Sub};
 
-fn lerp<T, U, V, F>(a: T, b: T, f: F) -> T
+pub fn lerp<T, U, V, F>(a: T, b: T, f: F) -> T
 where
     T: Sub<T, Output = U> + Add<V, Output = T> + Clone,
     U: Mul<F, Output = V>,

--- a/src/lerp.rs
+++ b/src/lerp.rs
@@ -1,0 +1,9 @@
+use std::ops::{Add, Mul, Sub};
+
+fn lerp<T, U, V, F>(a: T, b: T, f: F) -> T
+where
+    T: Sub<T, Output = U> + Add<V, Output = T> + Clone,
+    U: Mul<F, Output = V>,
+{
+    b.clone() + (a - b) * f
+}

--- a/src/lerp.rs
+++ b/src/lerp.rs
@@ -8,9 +8,3 @@ where
 {
     (b - &a) * f + a
 }
-
-#[test]
-fn name() {
-    let x = lerp(0.0, 1.0, 0.25);
-    print!("{}", x);
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,5 @@ pub use self::rect::*;
 
 mod lerp;
 pub use self::lerp::*;
+
+extern crate num_traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,6 @@ pub use self::size::*;
 
 mod rect;
 pub use self::rect::*;
+
+mod lerp;
+pub use self::lerp::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use] mod op;
+
 mod scalar;
 pub use self::scalar::*;
 

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,0 +1,66 @@
+macro_rules! op_term {
+    ($type: ident, $uname: ident, $lname: ident, $uaname: ident, $laname: ident, $( $member: ident ),*) => {
+        impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS> $uname<$type<RHS, Unit>>
+            for $type<T, Unit>
+        {
+            type Output = $type<Output, Unit>;
+            fn $lname(self, rhs: $type<RHS, Unit>) -> Self::Output {
+                Self::Output::new( $(self.$member.$lname(rhs.$member),)* )
+            }
+        }
+
+        impl<'a, T: $uname<&'a RHS, Output = Output>, Unit, Output, RHS>
+            $uname<&'a $type<RHS, Unit>> for $type<T, Unit>
+        {
+            type Output = $type<Output, Unit>;
+            fn $lname(self, rhs: &'a $type<RHS, Unit>) -> Self::Output {
+                Self::Output::new( $(self.$member.$lname(&rhs.$member),)* )
+            }
+        }
+
+        impl<T: $uaname<RHS>, Unit, RHS> $uaname<$type<RHS, Unit>> for $type<T, Unit> {
+            fn $laname(&mut self, rhs: $type<RHS, Unit>) {
+                $( self.$member.$laname(rhs.$member); )*
+            }
+        }
+
+        impl<'a, T: $uaname<&'a RHS>, Unit, RHS> $uaname<&'a $type<RHS, Unit>>
+            for $type<T, Unit>
+        {
+            fn $laname(&mut self, rhs: &'a $type<RHS, Unit>) {
+                $( self.$member.$laname(&rhs.$member); )*
+            }
+        }
+    };
+}
+
+macro_rules! op_factor {
+    ($type: ident, $uname: ident, $lname: ident, $uaname: ident, $laname: ident, $member: ident) => {
+        impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS> $uname<RHS> for $type<T, Unit> {
+            type Output = $type<Output, Unit>;
+            fn $lname(self, rhs: RHS) -> Self::Output {
+                Self::Output::new(self.$member.$lname(rhs))
+            }
+        }
+        impl<T: $uaname<RHS>, Unit, RHS> $uaname<RHS> for $type<T, Unit> {
+            fn $laname(&mut self, rhs: RHS) {
+                self.$member.$laname(rhs);
+            }
+        }
+    };
+
+    ($type: ident, $uname: ident, $lname: ident, $uaname: ident, $laname: ident, $member: ident, $( $members: ident ),+) => {
+        impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS: Copy> $uname<RHS> for $type<T, Unit> {
+            type Output = $type<Output, Unit>;
+            fn $lname(self, rhs: RHS) -> Self::Output {
+                Self::Output::new( self.$member.$lname(rhs), $(self.$members.$lname(rhs),)* )
+            }
+        }
+        impl<T: $uaname<RHS>, Unit, RHS: Copy> $uaname<RHS> for $type<T, Unit> {
+            fn $laname(&mut self, rhs: RHS) {
+                self.$member.$laname(rhs);
+                $( self.$members.$laname(rhs); )*
+            }
+        }
+    };
+}

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,4 +1,5 @@
 use crate::{scalar::Scalar, vector::Vector};
+use std::ops::{Add, Sub};
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Point<T, Unit> {
@@ -18,5 +19,26 @@ impl<T, Unit> Point<T, Unit> {
 
     pub fn y(&self) -> &Scalar<T, Unit> {
         &self.vector.dy
+    }
+}
+
+impl<T: Sub<Output = Output>, Unit, Output> Sub<Point<T, Unit>> for Point<T, Unit> {
+    type Output = Vector<Output, Unit>;
+    fn sub(self, p: Point<T, Unit>) -> Self::Output {
+        self.vector - p.vector
+    }
+}
+
+impl<T: Add<Output = Output>, Unit, Output> Add<Vector<T, Unit>> for Point<T, Unit> {
+    type Output = Point<Output, Unit>;
+    fn add(self, v: Vector<T, Unit>) -> Self::Output {
+        Point { vector: self.vector + v }
+    }
+}
+
+impl<T: Sub<Output = Output>, Unit, Output> Sub<Vector<T, Unit>> for Point<T, Unit> {
+    type Output = Point<Output, Unit>;
+    fn sub(self, v: Vector<T, Unit>) -> Self::Output {
+        Point { vector: self.vector - v }
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -1,4 +1,5 @@
-use crate::{point::Point, scalar::Scalar};
+use crate::{lerp::lerp, point::Point, scalar::Scalar};
+use std::ops::{Add, Mul, Sub};
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Rect<T, Unit> {
@@ -49,6 +50,43 @@ impl<T: PartialOrd + Clone, Unit> Rect<T, Unit> {
 
     pub fn bottom_right(&self) -> Point<T, Unit> {
         Point::new(self.right(), self.bottom())
+    }
+}
+
+impl<T, U, V, Unit> Rect<T, Unit>
+where
+    T: Sub<T, Output = U> + Add<V, Output = T> + Clone,
+    U: Mul<f32, Output = V>,
+{
+    pub fn center_x(&self) -> Scalar<T, Unit> {
+        lerp(self.a.x().clone(), self.b.x().clone(), 0.5)
+    }
+
+    pub fn center_y(&self) -> Scalar<T, Unit> {
+        lerp(self.a.y().clone(), self.b.y().clone(), 0.5)
+    }
+
+    pub fn center(&self) -> Point<T, Unit> {
+        Point::new(self.center_x(), self.center_y())
+    }
+}
+
+impl<T, U, V, Unit> Rect<T, Unit>
+where
+    T: Sub<T, Output = U> + Add<V, Output = T> + Clone + PartialOrd,
+    U: Mul<f32, Output = V>,
+{
+    pub fn center_left(&self) -> Point<T, Unit> {
+        Point::new(self.left(), self.center_y())
+    }
+    pub fn center_right(&self) -> Point<T, Unit> {
+        Point::new(self.right(), self.center_y())
+    }
+    pub fn top_center(&self) -> Point<T, Unit> {
+        Point::new(self.center_x(), self.top())
+    }
+    pub fn bottom_center(&self) -> Point<T, Unit> {
+        Point::new(self.center_x(), self.bottom())
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -1,5 +1,6 @@
-use crate::{lerp::lerp, point::Point, scalar::Scalar};
-use std::ops::{Add, Mul, Sub};
+use crate::{point::Point, scalar::Scalar};
+use num_traits::One;
+use std::ops::{Add, Div};
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Rect<T, Unit> {
@@ -53,29 +54,23 @@ impl<T: PartialOrd + Clone, Unit> Rect<T, Unit> {
     }
 }
 
-impl<T, U, V, Unit> Rect<T, Unit>
-where
-    T: Sub<T, Output = U> + Add<V, Output = T> + Clone,
-    U: Mul<f32, Output = V>,
-{
-    pub fn center_x(&self) -> Scalar<T, Unit> {
-        lerp(self.a.x().clone(), self.b.x().clone(), 0.5)
+impl<T: Clone + One + Add<Output = U>, Unit, U: Div<Output = Output>, Output> Rect<T, Unit> {
+    pub fn center_x(&self) -> Scalar<Output, Unit> {
+        let two = T::one() + T::one();
+        (self.a.x().clone() + self.b.x().clone()) / two
     }
 
-    pub fn center_y(&self) -> Scalar<T, Unit> {
-        lerp(self.a.y().clone(), self.b.y().clone(), 0.5)
+    pub fn center_y(&self) -> Scalar<Output, Unit> {
+        let two = T::one() + T::one();
+        (self.a.y().clone() + self.b.y().clone()) / two
     }
 
-    pub fn center(&self) -> Point<T, Unit> {
+    pub fn center(&self) -> Point<Output, Unit> {
         Point::new(self.center_x(), self.center_y())
     }
 }
 
-impl<T, U, V, Unit> Rect<T, Unit>
-where
-    T: Sub<T, Output = U> + Add<V, Output = T> + Clone + PartialOrd,
-    U: Mul<f32, Output = V>,
-{
+impl<T: PartialOrd + Clone + One + Add<Output = U>, Unit, U: Div<Output = T>> Rect<T, Unit> {
     pub fn center_left(&self) -> Point<T, Unit> {
         Point::new(self.left(), self.center_y())
     }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -6,8 +6,6 @@ use std::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
 };
 
-use crate::{op};
-
 // TODO should forward all trait functions, not just those w/o defaults
 
 #[derive(Debug)] // TODO don't derive Debug

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -6,6 +6,8 @@ use std::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
 };
 
+use crate::{op};
+
 // TODO should forward all trait functions, not just those w/o defaults
 
 #[derive(Debug)] // TODO don't derive Debug
@@ -105,62 +107,8 @@ impl<T: Sum<A>, Unit, A> Sum<Scalar<A, Unit>> for Scalar<T, Unit> {
     }
 }
 
-macro_rules! op_term {
-    ($uname: ident, $lname: ident, $uaname: ident, $laname: ident) => {
-        impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS> $uname<Scalar<RHS, Unit>>
-            for Scalar<T, Unit>
-        {
-            type Output = Scalar<Output, Unit>;
-            fn $lname(self, rhs: Scalar<RHS, Unit>) -> Self::Output {
-                self.t.$lname(rhs.t).into()
-            }
-        }
-
-        impl<'a, T: $uname<&'a RHS, Output = Output>, Unit, Output, RHS>
-            $uname<&'a Scalar<RHS, Unit>> for Scalar<T, Unit>
-        {
-            type Output = Scalar<Output, Unit>;
-            fn $lname(self, rhs: &'a Scalar<RHS, Unit>) -> Self::Output {
-                self.t.$lname(&rhs.t).into()
-            }
-        }
-
-        impl<T: $uaname<RHS>, Unit, RHS> $uaname<Scalar<RHS, Unit>> for Scalar<T, Unit> {
-            fn $laname(&mut self, rhs: Scalar<RHS, Unit>) {
-                self.t.$laname(rhs.t)
-            }
-        }
-
-        impl<'a, T: $uaname<&'a RHS>, Unit, RHS> $uaname<&'a Scalar<RHS, Unit>>
-            for Scalar<T, Unit>
-        {
-            fn $laname(&mut self, rhs: &'a Scalar<RHS, Unit>) {
-                self.t.$laname(&rhs.t)
-            }
-        }
-    };
-}
-
-macro_rules! op_factor {
-    ($uname: ident, $lname: ident, $uaname: ident, $laname: ident) => {
-        impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS> $uname<RHS> for Scalar<T, Unit> {
-            type Output = Scalar<Output, Unit>;
-
-            fn $lname(self, rhs: RHS) -> Self::Output {
-                self.t.$lname(rhs).into()
-            }
-        }
-
-        impl<T: $uaname<RHS>, Unit, RHS> $uaname<RHS> for Scalar<T, Unit> {
-            fn $laname(&mut self, rhs: RHS) {
-                self.t.$laname(rhs)
-            }
-        }
-    };
-}
-
-op_term!(Add, add, AddAssign, add_assign);
-op_term!(Sub, sub, SubAssign, sub_assign);
-op_factor!(Rem, rem, RemAssign, rem_assign);
-op_factor!(Div, div, DivAssign, div_assign);
-op_factor!(Mul, mul, MulAssign, mul_assign);
+op_term!(Scalar, Add, add, AddAssign, add_assign, t);
+op_term!(Scalar, Sub, sub, SubAssign, sub_assign, t);
+op_factor!(Scalar, Rem, rem, RemAssign, rem_assign, t);
+op_factor!(Scalar, Div, div, DivAssign, div_assign, t);
+op_factor!(Scalar, Mul, mul, MulAssign, mul_assign, t);

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -105,7 +105,7 @@ impl<T: Sum<A>, Unit, A> Sum<Scalar<A, Unit>> for Scalar<T, Unit> {
     }
 }
 
-macro_rules! op {
+macro_rules! op_term {
     ($uname: ident, $lname: ident, $uaname: ident, $laname: ident) => {
         impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS> $uname<Scalar<RHS, Unit>>
             for Scalar<T, Unit>
@@ -141,8 +141,26 @@ macro_rules! op {
     };
 }
 
-op!(Sub, sub, SubAssign, sub_assign);
-op!(Rem, rem, RemAssign, rem_assign);
-op!(Div, div, DivAssign, div_assign);
-op!(Mul, mul, MulAssign, mul_assign);
-op!(Add, add, AddAssign, add_assign);
+macro_rules! op_factor {
+    ($uname: ident, $lname: ident, $uaname: ident, $laname: ident) => {
+        impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS> $uname<RHS> for Scalar<T, Unit> {
+            type Output = Scalar<Output, Unit>;
+
+            fn $lname(self, rhs: RHS) -> Self::Output {
+                self.t.$lname(rhs).into()
+            }
+        }
+
+        impl<T: $uaname<RHS>, Unit, RHS> $uaname<RHS> for Scalar<T, Unit> {
+            fn $laname(&mut self, rhs: RHS) {
+                self.t.$laname(rhs)
+            }
+        }
+    };
+}
+
+op_term!(Add, add, AddAssign, add_assign);
+op_term!(Sub, sub, SubAssign, sub_assign);
+op_factor!(Rem, rem, RemAssign, rem_assign);
+op_factor!(Div, div, DivAssign, div_assign);
+op_factor!(Mul, mul, MulAssign, mul_assign);

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,4 +1,4 @@
-use crate::scalar::Scalar;
+use crate::{op, scalar::Scalar};
 use std::{
     marker::PhantomData,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
@@ -28,65 +28,8 @@ impl<T: Neg<Output = Output>, Unit, Output> Neg for Vector<T, Unit> {
     }
 }
 
-macro_rules! op_term {
-    ($uname: ident, $lname: ident, $uaname: ident, $laname: ident) => {
-        impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS> $uname<Vector<RHS, Unit>>
-            for Vector<T, Unit>
-        {
-            type Output = Vector<Output, Unit>;
-            fn $lname(self, rhs: Vector<RHS, Unit>) -> Self::Output {
-                Self::Output::new(self.dx.$lname(rhs.dx), self.dy.$lname(rhs.dy))
-            } 
-        }
-
-        impl<'a, T: $uname<&'a RHS, Output = Output>, Unit, Output, RHS>
-            $uname<&'a Vector<RHS, Unit>> for Vector<T, Unit>
-        {
-            type Output = Vector<Output, Unit>;
-            fn $lname(self, rhs: &'a Vector<RHS, Unit>) -> Self::Output {
-                Self::Output::new(self.dx.$lname(&rhs.dx), self.dy.$lname(&rhs.dy))
-            }
-        }
-
-        impl<T: $uaname<RHS>, Unit, RHS> $uaname<Vector<RHS, Unit>> for Vector<T, Unit> {
-            fn $laname(&mut self, rhs: Vector<RHS, Unit>) {
-                self.dx.$laname(rhs.dx);
-                self.dy.$laname(rhs.dy)
-            }
-        }
-
-        impl<'a, T: $uaname<&'a RHS>, Unit, RHS> $uaname<&'a Vector<RHS, Unit>>
-            for Vector<T, Unit>
-        {
-            fn $laname(&mut self, rhs: &'a Vector<RHS, Unit>) {
-                self.dx.$laname(&rhs.dx);
-                self.dy.$laname(&rhs.dy)
-            }
-        }
-    };
-}
-
-macro_rules! op_factor {
-    ($uname: ident, $lname: ident, $uaname: ident, $laname: ident) => {
-        impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS: Clone> $uname<RHS> for Vector<T, Unit> {
-            type Output = Vector<Output, Unit>;
-
-            fn $lname(self, rhs: RHS) -> Self::Output {
-                Vector::new(self.dx.$lname(rhs.clone()), self.dy.$lname(rhs))
-            }
-        }
-
-        impl<T: $uaname<RHS>, Unit, RHS: Clone> $uaname<RHS> for Vector<T, Unit> {
-            fn $laname(&mut self, rhs: RHS) {
-                self.dx.$laname(rhs.clone());
-                self.dy.$laname(rhs)
-            }
-        }
-    };
-}
-
-op_term!(Add, add, AddAssign, add_assign);
-op_term!(Sub, sub, SubAssign, sub_assign);
-op_factor!(Rem, rem, RemAssign, rem_assign);
-op_factor!(Div, div, DivAssign, div_assign);
-op_factor!(Mul, mul, MulAssign, mul_assign);
+op_term!(Vector, Add, add, AddAssign, add_assign, dx, dy);
+op_term!(Vector, Sub, sub, SubAssign, sub_assign, dx, dy);
+op_factor!(Vector, Rem, rem, RemAssign, rem_assign, dx, dy);
+op_factor!(Vector, Div, div, DivAssign, div_assign, dx, dy);
+op_factor!(Vector, Mul, mul, MulAssign, mul_assign, dx, dy);

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,4 +1,4 @@
-use crate::{op, scalar::Scalar};
+use crate::{scalar::Scalar};
 use std::{
     marker::PhantomData,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -21,6 +21,13 @@ impl<T, Unit> Vector<T, Unit> {
     }
 }
 
+impl<T: Neg<Output = Output>, Unit, Output> Neg for Vector<T, Unit> {
+    type Output = Vector<Output, Unit>;
+    fn neg(self) -> Self::Output {
+        Self::Output::new(-self.dx, -self.dy)
+    }
+}
+
 macro_rules! op_term {
     ($uname: ident, $lname: ident, $uaname: ident, $laname: ident) => {
         impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS> $uname<Vector<RHS, Unit>>
@@ -28,7 +35,7 @@ macro_rules! op_term {
         {
             type Output = Vector<Output, Unit>;
             fn $lname(self, rhs: Vector<RHS, Unit>) -> Self::Output {
-                Vector::new(self.dx.$lname(rhs.dx), self.dy.$lname(rhs.dy))
+                Self::Output::new(self.dx.$lname(rhs.dx), self.dy.$lname(rhs.dy))
             } 
         }
 
@@ -37,7 +44,7 @@ macro_rules! op_term {
         {
             type Output = Vector<Output, Unit>;
             fn $lname(self, rhs: &'a Vector<RHS, Unit>) -> Self::Output {
-                Vector::new(self.dx.$lname(&rhs.dx), self.dy.$lname(&rhs.dy))
+                Self::Output::new(self.dx.$lname(&rhs.dx), self.dy.$lname(&rhs.dy))
             }
         }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,5 +1,8 @@
 use crate::scalar::Scalar;
-use std::marker::PhantomData;
+use std::{
+    marker::PhantomData,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
+};
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Vector<T, Unit> {
@@ -17,3 +20,66 @@ impl<T, Unit> Vector<T, Unit> {
         }
     }
 }
+
+macro_rules! op_term {
+    ($uname: ident, $lname: ident, $uaname: ident, $laname: ident) => {
+        impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS> $uname<Vector<RHS, Unit>>
+            for Vector<T, Unit>
+        {
+            type Output = Vector<Output, Unit>;
+            fn $lname(self, rhs: Vector<RHS, Unit>) -> Self::Output {
+                Vector::new(self.dx.$lname(rhs.dx), self.dy.$lname(rhs.dy))
+            } 
+        }
+
+        impl<'a, T: $uname<&'a RHS, Output = Output>, Unit, Output, RHS>
+            $uname<&'a Vector<RHS, Unit>> for Vector<T, Unit>
+        {
+            type Output = Vector<Output, Unit>;
+            fn $lname(self, rhs: &'a Vector<RHS, Unit>) -> Self::Output {
+                Vector::new(self.dx.$lname(&rhs.dx), self.dy.$lname(&rhs.dy))
+            }
+        }
+
+        impl<T: $uaname<RHS>, Unit, RHS> $uaname<Vector<RHS, Unit>> for Vector<T, Unit> {
+            fn $laname(&mut self, rhs: Vector<RHS, Unit>) {
+                self.dx.$laname(rhs.dx);
+                self.dy.$laname(rhs.dy)
+            }
+        }
+
+        impl<'a, T: $uaname<&'a RHS>, Unit, RHS> $uaname<&'a Vector<RHS, Unit>>
+            for Vector<T, Unit>
+        {
+            fn $laname(&mut self, rhs: &'a Vector<RHS, Unit>) {
+                self.dx.$laname(&rhs.dx);
+                self.dy.$laname(&rhs.dy)
+            }
+        }
+    };
+}
+
+macro_rules! op_factor {
+    ($uname: ident, $lname: ident, $uaname: ident, $laname: ident) => {
+        impl<T: $uname<RHS, Output = Output>, Unit, Output, RHS: Clone> $uname<RHS> for Vector<T, Unit> {
+            type Output = Vector<Output, Unit>;
+
+            fn $lname(self, rhs: RHS) -> Self::Output {
+                Vector::new(self.dx.$lname(rhs.clone()), self.dy.$lname(rhs))
+            }
+        }
+
+        impl<T: $uaname<RHS>, Unit, RHS: Clone> $uaname<RHS> for Vector<T, Unit> {
+            fn $laname(&mut self, rhs: RHS) {
+                self.dx.$laname(rhs.clone());
+                self.dy.$laname(rhs)
+            }
+        }
+    };
+}
+
+op_term!(Add, add, AddAssign, add_assign);
+op_term!(Sub, sub, SubAssign, sub_assign);
+op_factor!(Rem, rem, RemAssign, rem_assign);
+op_factor!(Div, div, DivAssign, div_assign);
+op_factor!(Mul, mul, MulAssign, mul_assign);


### PR DESCRIPTION
- remove Mul for `Scalar<T> * Scalar<T>`, replace with `Scalar<T> * T` instead (likewise for Div and Rem)
- factor out Scalar's ops macros into ones that work for Vector too
- ops for Vector and Point
- generic lerp function
- rect center* functions in terms of lerp