### PR TITLE
More robust transforming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Added `from_x`, `from_y`, `map_x`, and `map_y` to `Point`.
 - Added `Rect::inset_` and `Rect::outset_` conveniences for each edge.
 - **Breaking:** Renamed `Transform::rotation_with_fixed_point` to `Transform::rotation`. The previous `Transform::rotation` behavior can be achieved by specifying a center of `Point::zero()`. The signatures of `Transform::post_rotate` and `Transform::pre_rotate` have changed accordingly.
+- Added `transform_point`, `transform_vector`, and `transform_rect` to both `Transform` and `Transform3d`. These are equivalent to calling e.g. `point.transform(tx)`, but may be more convenient (and more discoverable) in some cases.
+- **Breaking:** `Rect::transform` now returns a `Quad` to preserve more information for the caller. The previous behavior can be achieved by calling `.aabb()` on the resulting `Quad` (and then `Deref`ing the result).
+- **Breaking:** `Vector::transform` now takes `self` by value for consistency with `Point::transform` and `Rect::transform`.
 
 # 0.3.0 (2021-08-26)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ license = "Apache-2.0/MIT"
 default = []
 
 [dependencies]
-derive_more = "0.99.17"
 en = "0.1.5"
 euclid = { version = "0.22.6", optional = true }
 d6 = { git = "https://github.com/BrainiumLLC/d6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ license = "Apache-2.0/MIT"
 default = []
 
 [dependencies]
+derive_more = "0.99.17"
 en = "0.1.5"
 euclid = { version = "0.22.6", optional = true }
 d6 = { git = "https://github.com/BrainiumLLC/d6", optional = true }
+itertools = "0.10.3"
 serde = { version = "1.0.115", features = ["derive"], optional = true }
 strum = "0.22.0"
 strum_macros = "0.22.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,11 @@ mod ellipse;
 mod lerp;
 mod line_segment;
 mod point;
-mod quad;
 mod ray;
 mod rect;
 mod rect_position;
 mod size;
+mod support;
 mod transform;
 mod transform3d;
 mod vector;
@@ -22,8 +22,8 @@ mod vector;
 pub mod split;
 
 pub use self::{
-    angle::*, circle::*, direction::*, ellipse::*, lerp::*, line_segment::*, point::*, quad::*,
-    ray::*, rect::*, rect_position::*, size::*, transform::*, transform3d::*, vector::*,
+    angle::*, circle::*, direction::*, ellipse::*, lerp::*, line_segment::*, point::*, ray::*,
+    rect::*, rect_position::*, size::*, support::*, transform::*, transform3d::*, vector::*,
 };
 pub use en;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 #[macro_use]
 mod cast;
 
@@ -8,6 +10,7 @@ mod ellipse;
 mod lerp;
 mod line_segment;
 mod point;
+mod quad;
 mod ray;
 mod rect;
 mod rect_position;
@@ -19,8 +22,8 @@ mod vector;
 pub mod split;
 
 pub use self::{
-    angle::*, circle::*, direction::*, ellipse::*, lerp::*, line_segment::*, point::*, ray::*,
-    rect::*, rect_position::*, size::*, transform::*, transform3d::*, vector::*,
+    angle::*, circle::*, direction::*, ellipse::*, lerp::*, line_segment::*, point::*, quad::*,
+    ray::*, rect::*, rect_position::*, size::*, transform::*, transform3d::*, vector::*,
 };
 pub use en;
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -45,7 +45,7 @@ impl<T: en::Num> Point<T> {
     }
 
     pub fn transform(self, transform: Transform<T>) -> Self {
-        self.to_vector().transform(transform).to_point()
+        transform.transform_point(self)
     }
 
     pub fn map<U: en::Num>(self, mut f: impl FnMut(T) -> U) -> Point<U> {

--- a/src/quad.rs
+++ b/src/quad.rs
@@ -1,0 +1,69 @@
+use crate::{Point, Rect, AABB};
+use itertools::{Itertools, MinMaxResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+/// A `Quad` is a structure of 4 points that gives no specific guarantees about the relationship between them.
+/// This is the output of transforming a `Rect` by an arbitrary transform, where the result might not be a `Rect`
+/// anymore due to rotation/perspective distortion/etc.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(C)]
+pub struct Quad<T = f32> {
+    pub a: Point<T>,
+    pub b: Point<T>,
+    pub c: Point<T>,
+    pub d: Point<T>,
+}
+
+impl<T: en::Float> Quad<T> {
+    fn aabb(&self) -> AABB<T> {
+        let verts = [self.a, self.b, self.c, self.d];
+        let (min_x, max_x) = unsafe { min_max(verts.iter().map(|v| v.x)) };
+        let (min_y, max_y) = unsafe { min_max(verts.iter().map(|v| v.y)) };
+        Rect::from_top_right_bottom_left(min_y, max_x, max_y, min_x).into()
+    }
+}
+
+/// Safety: iter must have >1 element
+unsafe fn min_max<T: PartialOrd>(i: impl IntoIterator<Item = T>) -> (T, T) {
+    match i.into_iter().minmax() {
+        MinMaxResult::MinMax(min, max) => (min, max),
+        _ => unsafe { std::hint::unreachable_unchecked() },
+    }
+}
+
+/// An intermediate type produced by transforming a `Rect` by a `Transform3d`.
+#[derive(Debug)]
+struct Quad4d<T = f32> {
+    pub a: Point4d<T>,
+    pub b: Point4d<T>,
+    pub c: Point4d<T>,
+    pub d: Point4d<T>,
+}
+
+impl<T: en::Num> Quad4d<T> {
+    pub fn truncate(self) -> Quad<T> {
+        Quad {
+            a: self.a.truncate(),
+            b: self.b.truncate(),
+            c: self.c.truncate(),
+            d: self.d.truncate(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Point4d<T = f32> {
+    pub x: T,
+    pub y: T,
+    pub z: T,
+    pub w: T,
+}
+
+impl<T: en::Num> Point4d<T> {
+    pub fn truncate(self) -> Point<T> {
+        Point::new(self.x, self.y)
+    }
+}

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -1,6 +1,6 @@
 use crate::{
-    HorizontalLocation, LineSegment, Point, RectLocation, RectPosition, Size, Transform, Vector,
-    VerticalLocation,
+    HorizontalLocation, LineSegment, Point, Quad, RectLocation, RectPosition, Size, Transform,
+    Vector, VerticalLocation,
 };
 use derive_more::{Deref, DerefMut, From};
 #[cfg(feature = "serde")]
@@ -501,11 +501,8 @@ impl<T: en::Num> Rect<T> {
         self.outset(T::zero(), T::zero(), T::zero(), left)
     }
 
-    pub fn transform(self, transform: Transform<T>) -> Self {
-        Self::from_iter(
-            self.clockwise_points()
-                .map(|point| point.transform(transform)),
-        )
+    pub fn transform(self, transform: Transform<T>) -> Quad<T> {
+        transform.transform_rect(self)
     }
 
     pub fn line_segments(&self) -> [LineSegment<T>; 4] {

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -2,7 +2,6 @@ use crate::{
     HorizontalLocation, LineSegment, Point, Quad, RectLocation, RectPosition, Size, Transform,
     Vector, VerticalLocation,
 };
-use derive_more::{Deref, DerefMut, From};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
@@ -769,21 +768,6 @@ impl<T: en::Num, U> From<Rect<T>> for euclid::Rect<T, U> {
 impl<T: en::Num, U> From<euclid::Rect<T, U>> for Rect<T> {
     fn from(r: euclid::Rect<T, U>) -> Rect<T> {
         Self::from_top_left(r.origin.into(), r.size.into())
-    }
-}
-
-/// An axis-aligned bounding box. Identical to `Rect`, but newtyped to flag it as a different concept.
-/// The `Rect` API is accessible through `Deref`/`DerefMut`.
-#[derive(
-    Clone, Copy, Debug, Default, Deref, DerefMut, From, Eq, Hash, Ord, PartialEq, PartialOrd,
-)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[repr(transparent)]
-pub struct AABB<T>(Rect<T>);
-
-impl<T: en::Num> From<AABB<T>> for Rect<T> {
-    fn from(a: AABB<T>) -> Self {
-        *a
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -2,6 +2,7 @@ use crate::{
     HorizontalLocation, LineSegment, Point, RectLocation, RectPosition, Size, Transform, Vector,
     VerticalLocation,
 };
+use derive_more::{Deref, DerefMut, From};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
@@ -771,6 +772,21 @@ impl<T: en::Num, U> From<Rect<T>> for euclid::Rect<T, U> {
 impl<T: en::Num, U> From<euclid::Rect<T, U>> for Rect<T> {
     fn from(r: euclid::Rect<T, U>) -> Rect<T> {
         Self::from_top_left(r.origin.into(), r.size.into())
+    }
+}
+
+/// An axis-aligned bounding box. Identical to `Rect`, but newtyped to flag it as a different concept.
+/// The `Rect` API is accessible through `Deref`/`DerefMut`.
+#[derive(
+    Clone, Copy, Debug, Default, Deref, DerefMut, From, Eq, Hash, Ord, PartialEq, PartialOrd,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(transparent)]
+pub struct AABB<T>(Rect<T>);
+
+impl<T: en::Num> From<AABB<T>> for Rect<T> {
+    fn from(a: AABB<T>) -> Self {
+        *a
     }
 }
 

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,8 +1,7 @@
-use crate::{Point, Rect, AABB};
+use crate::{Point, Rect, Vector, AABB};
 use itertools::{Itertools, MinMaxResult};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
 /// A `Quad` is a structure of 4 points that gives no specific guarantees about the relationship between them.
 /// This is the output of transforming a `Rect` by an arbitrary transform, where the result might not be a `Rect`
@@ -18,7 +17,8 @@ pub struct Quad<T = f32> {
 }
 
 impl<T: en::Float> Quad<T> {
-    fn aabb(&self) -> AABB<T> {
+    /// Computes the axis-aligned bounding box of the quad.
+    pub fn aabb(&self) -> AABB<T> {
         let verts = [self.a, self.b, self.c, self.d];
         let (min_x, max_x) = unsafe { min_max(verts.iter().map(|v| v.x)) };
         let (min_y, max_y) = unsafe { min_max(verts.iter().map(|v| v.y)) };
@@ -34,36 +34,17 @@ unsafe fn min_max<T: PartialOrd>(i: impl IntoIterator<Item = T>) -> (T, T) {
     }
 }
 
-/// An intermediate type produced by transforming a `Rect` by a `Transform3d`.
-#[derive(Debug)]
-struct Quad4d<T = f32> {
-    pub a: Point4d<T>,
-    pub b: Point4d<T>,
-    pub c: Point4d<T>,
-    pub d: Point4d<T>,
-}
-
-impl<T: en::Num> Quad4d<T> {
-    pub fn truncate(self) -> Quad<T> {
-        Quad {
-            a: self.a.truncate(),
-            b: self.b.truncate(),
-            c: self.c.truncate(),
-            d: self.d.truncate(),
-        }
-    }
-}
-
+/// An intermediate type that gets produced when transforming a `Vector` by a `Transform3d`.
 #[derive(Clone, Copy, Debug)]
-struct Point4d<T = f32> {
-    pub x: T,
-    pub y: T,
-    pub z: T,
-    pub w: T,
+pub(crate) struct Vector4d<T = f32> {
+    pub dx: T,
+    pub dy: T,
+    pub dz: T,
+    pub dw: T,
 }
 
-impl<T: en::Num> Point4d<T> {
-    pub fn truncate(self) -> Point<T> {
-        Point::new(self.x, self.y)
+impl<T: en::Num> Vector4d<T> {
+    pub fn truncate(self) -> Vector<T> {
+        Vector::new(self.dx, self.dy)
     }
 }

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,4 +1,4 @@
-use crate::{Point, Rect, Vector, AABB};
+use crate::{Point, Rect, Vector};
 use itertools::{Itertools, MinMaxResult};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -18,11 +18,11 @@ pub struct Quad<T = f32> {
 
 impl<T: en::Float> Quad<T> {
     /// Computes the axis-aligned bounding box of the quad.
-    pub fn aabb(&self) -> AABB<T> {
+    pub fn aabb(&self) -> Rect<T> {
         let verts = [self.a, self.b, self.c, self.d];
         let (min_x, max_x) = unsafe { min_max(verts.iter().map(|v| v.x)) };
         let (min_y, max_y) = unsafe { min_max(verts.iter().map(|v| v.y)) };
-        Rect::from_top_right_bottom_left(min_y, max_x, max_y, min_x).into()
+        Rect::from_top_right_bottom_left(min_y, max_x, max_y, min_x)
     }
 }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,4 +1,4 @@
-use crate::{Angle, Point, Vector};
+use crate::{Angle, Point, Quad, Rect, Vector};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -294,6 +294,28 @@ impl<T: en::Num> Transform<T> {
     }
 
     impl_casts_and_cast!(Transform);
+}
+
+impl<T: en::Num> Transform<T> {
+    pub fn transform_vector(&self, v: Vector<T>) -> Vector<T> {
+        Vector::new(
+            v.dx * self.m11 + v.dy * self.m21 + self.m31,
+            v.dx * self.m12 + v.dy * self.m22 + self.m32,
+        )
+    }
+
+    pub fn transform_point(&self, p: Point<T>) -> Point<T> {
+        self.transform_vector(p.to_vector()).to_point()
+    }
+
+    pub fn transform_rect(&self, rect: Rect<T>) -> Quad<T> {
+        Quad {
+            a: self.transform_point(rect.top_left()),
+            b: self.transform_point(rect.top_right()),
+            c: self.transform_point(rect.bottom_right()),
+            d: self.transform_point(rect.bottom_left()),
+        }
+    }
 }
 
 #[cfg(feature = "euclid")]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -98,11 +98,8 @@ impl<T: en::Num> Vector<T> {
         Self::new(self.dy, self.dx)
     }
 
-    pub fn transform(&self, transform: Transform<T>) -> Self {
-        Self::new(
-            self.dx * transform.m11 + self.dy * transform.m21 + transform.m31,
-            self.dx * transform.m12 + self.dy * transform.m22 + transform.m32,
-        )
+    pub fn transform(self, transform: Transform<T>) -> Self {
+        transform.transform_vector(self)
     }
 
     pub fn map<U: en::Num>(&self, mut f: impl FnMut(T) -> U) -> Vector<U> {


### PR DESCRIPTION
There are two issues (in my opinion) with the current APIs for actually applying a transform to vectors/points/etc:

1. The APIs are asymmetrical and possibly hard to discover. There's `point.transform(tx)`, but no `tx.transform_point(p)`. This runs counter to other friendly symmetrical APIs in `gee`, like `Point::to_vector` and `Vector::to_point`. 
    - On top of that, it took me like 6 months of working with `gee` to even notice that `point.transform(tx)` existed (it actually didn't happen until I was working on this PR). I looked for a `transform_point` function on `Transform`, didn't find one, and concluded that `gee` couldn't apply transforms for me, so I've been writing out the math manually where I've needed it. Many [other](https://docs.cocos2d-x.org/api-ref/cplusplus/V3.1/dc/dce/class_mat4.html#a8ee1da8503626ed6943e6bd764e12145) [math libraries](https://docs.rs/euclid/0.20.0/euclid/struct.Transform2D.html#method.transform_point) have transforming a point as a method on the `Transform` object, so I think we should be less surprising by following suit.
2. The existing `rect.transform(tx)` API throws away information. It transforms each point in the rect, and then returns you the smallest `Rect` that can hold all those points (a.k.a. the axis-aligned bounding box). For certain game calculations (like batch rendering), you really want the individual transformed points, and the option to turn them into an AABB yourself if you want.
---
This PR does its best to solve both issues.
- It adds `transform_vector`, `transform_point`, and `transform_rect` methods to both `Transform` and `Transform3d`. The `p.transform(tx)` methods are now implemented in terms of those.
- For transforming `Rect`s, the result type is no longer a `Rect`, but a `Quad`, which is just a bag of 4 points with no further guarantees (unlike `Rect`, whose representation guarantees that it is not rotated/skewed/distorted etc.). It contains the "raw" result of transforming each of the rect's vertices individually. If you'd rather have a `Rect` like the old behavior, you can turn that into an axis-aligned bounding box with the `Quad::aabb` method.